### PR TITLE
Allow users to control the name of the base VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Packer Builder for Anka
 
-This is a [Packer Builder] for building images that work with [Veertu Anka], a 
+This is a [Packer Builder] for building images that work with [Veertu Anka], a
 macOS virtualization tool.
 
 Note that this builder does not manage images. Once it creates an image, it is up
@@ -36,7 +36,7 @@ Must be `veertu-anka`
 
 * `installer_app` (optional)
 
-The path to a macOS installer. This must be provided if `source_vm_name` isn't 
+The path to a macOS installer. This must be provided if `source_vm_name` isn't
 provided. This process takes about 20 minutes
 
 * `disk_size` (optional)
@@ -54,6 +54,10 @@ The number of CPU cores, defaults to `2`
 * `source_vm_name` (optional)
 
 The VM to clone for provisioning, either stopped or suspended.
+
+If you specify both `source_vm_name` and `installer_app`, and a VM image with `source_vm_name`
+does not exist locally, a VM image with that name is created for you using the `installer_app`.
+This process takes about 20 minutes.
 
 * `vm_name` (optional)
 


### PR DESCRIPTION
When an Installer App is provided, the current behavior is to create a new VM named `anka-base-XXXXXXXXXX`. The trailing X's are random characters and in a CI system responsible for building images, this creates cruft.

This change introduces new behavior when a user specifies both a `source_vm_name` and an `installer_app`. If both are specified, rather than creating an image named `anka-base-XXXXXXXXXX`, it will create the VM using the `source_vm_name` (if it does not already exist). Then,  on subsequent rebuilds, the plugin will use the pre-existing `source_vm_name` rather than
re-doing the install procedure.

We've been using this locally in our Anka VM creation pipeline and its cut down on our build times dramatically. We can upload this clean image to our Registry and pull it down if we need it. It also allows us to easily trigger rebuilds by simply removing VMs from the registry. 

Signed-off-by: Tom Duffield <tom@chef.io>