### PR TITLE
Wire up dependabot to chase HEAD for dependencies automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+# https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    assignees:
+      - "NorseGaud"
+      - "asafg6"
+    reviewers:
+      - "NorseGaud"
+      - "asafg6"


### PR DESCRIPTION
Dependabot is awesome. It periodically checks your dependency manager config for updates it could apply, then opens PRs that look like https://github.com/aelsabbahy/goss/pull/625, auto-assigning reviewers etc

So, start to use github's dependabot to keep up to date with dependencies.

Periodically, it will look at the package manager file(s) (here, `go.mod`) and then see whether there are newer versions. If there are, it will open a beautifully generated PR containing links to release-notes, changelog, and diff between current version and the version it thinks to upgrade.

If CI is green, it's _possible_ to get the PR to auto-merge - that's obviously an appetite-for-risk/confidence-in-test-coverage question to answer.

Blog post announcing it - https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/

I've linked to the documentation within the comment in the file itself.