### PR TITLE
Propagate through config to create-VM for installer-cache-VM

### DIFF
--- a/builder/anka/step_create_vm.go
+++ b/builder/anka/step_create_vm.go
@@ -198,7 +198,13 @@ func (s *StepCreateVM) Run(ctx context.Context, state multistep.StateBag) multis
 				ui.Say(msg)
 			}
 		}()
-		if resp, err := s.client.Create(client.CreateParams{InstallerApp: config.InstallerApp, Name: sourceVMName}, outputStream); err != nil {
+		if resp, err := s.client.Create(client.CreateParams{
+			CPUCount:     config.CPUCount,
+			DiskSize:     config.DiskSize,
+			InstallerApp: config.InstallerApp,
+			Name:         sourceVMName,
+			RAMSize:      config.RAMSize,
+		}, outputStream); err != nil {
 			return onError(err)
 		} else {
 			ui.Say(fmt.Sprintf("VM %s was created (%s)", sourceVMName, resp.UUID))


### PR DESCRIPTION
I'm still confirming, but I'm attempting to solve for this error in my own template-building:

```
==> default: Creating a temporary directory for sharing data...
==> default: Extracting version from installer app: "/Users/petermounce/.cache/bakery/catalina/10.15.7/install-macos-catalina-10.15.7.app"
==> default: Creating a new base VM Template (anka-packer-base-10.15.6-15.7.02) from installer, this will take a while
==> default: Installing macOS 10.15.7...
==> default: Copying AnkaGuestAddons.pkg...
==> default: Converting to ANKA format...
==> default: VM anka-packer-base-10.15.6-15.7.02 was created (8f1fc6fc-64bb-4a42-bf5c-247dab75eb18)
==> default: Shrinking VM disks is not allowed! Source VM Disk Size (bytes): 137438953472
==> default: Deleting VM anka-packer-base-10.15.6-15.7.02
Build 'default' errored after 25 minutes 49 seconds: Shrinking VM disks is not allowed! Source VM Disk Size (bytes): 137438953472

==> Wait completed after 25 minutes 49 seconds

==> Some builds didn't complete successfully and had errors:
--> default: Shrinking VM disks is not allowed! Source VM Disk Size (bytes): 137438953472

==> Builds finished but no artifacts were created.
fatal: uncaught error
Traceback (most recent call first):
  at packer/improbable.io/buildkite/build-macos-bare-image.sh:103 in main()
packer build -color="false" -only="${PB_PACKER_BUILDER_NAME}" -var-file="packer-vars.json" -var "pb_mac_installer_app=${macos_installer_path}.app" -on-error="${PB_PACKER_ON_ERROR}" "./macos_bare.packer.json" exited 1
```