### PR TITLE
CLOUD-737: Attempt to stop VM before exiting during VM provision steps

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -39,6 +39,26 @@ func (c *Client) Version() (VersionResponse, error) {
 	return response, err
 }
 
+type LicenseResponse struct {
+	LicenseType string `json:"license_type"`
+	Status      string `json:"status"`
+}
+
+func (c *Client) License() (LicenseResponse, error) {
+	output, err := runAnkaCommand("license", "show")
+	if err != nil {
+		return LicenseResponse{}, err
+	}
+
+	var response LicenseResponse
+	err = json.Unmarshal(output.Body, &response)
+	if err != nil {
+		return response, err
+	}
+
+	return response, nil
+}
+
 type SuspendParams struct {
 	VMName string
 }


### PR DESCRIPTION
## Pull Request 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other: (describe here) 
  
## Proposed Change
<!-- Explain your change, its motivation, compare previous and new behaviour and link to issue, if exists -->
Issue Number: N/A
While trying out the new "develop" license option on my Macbook, I noticed that the Packer plugin cannot complete provisioning steps because the develop license cannot perform virtual machine suspensions.

<!-- Write your answer here -->
This PR allows the plugin to perform a clean stop on the virtual machine if a suspend attempt ends in an error and if a develop license type is present. If the stop attempt or license check returns an error, the plugin will return or panic as expected.

## Breaking Change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications here -->

## Checklist

Please validate that your PR fulfills the following requirements:
- [x] I have read the **CONTRIBUTING.md** documentation
- [ ] I have branched from the master branch
- [x] I have checked that a similar PR does not exist or has been rejected in the past
- [x] PR changes are specific to a feature or bug
- [x] No style/format/cosmetic changes included
- [x] I have used existing style and naming patterns in my changes
- [x] Tests for the changes have been added/updated (if relevant)
- [x] Built/compiled and tested locally
- [x] Docs have been added/updated (if relevant)
- [x] I have squashed my changes into a single commit


## Additional Information
<!-- Any other information that is important to this PR such as screenshots of how the feature/bug looked before and after the change. -->
Note that I have explicitly been asked to branch off of `release/v1.7.0` before implementing this change. Because of this request, I am currently targeting that branch in this PR.


Example of output before fix. Build fails and removes base image:

<img width="730" alt="Screen Shot 2021-01-08 at 4 51 15 PM" src="https://user-images.githubusercontent.com/49006827/104067825-dd6f3680-51d1-11eb-8d53-914765ba7c91.png">


Example of output after fix. Build continues after this information is displayed:
<img width="750" alt="Screen Shot 2021-01-24 at 14 23 23" src="https://user-images.githubusercontent.com/49006827/105641010-beb6a400-5e4f-11eb-9731-e8d3051e9558.png">
